### PR TITLE
Blocko: add check for OpenGL extension

### DIFF
--- a/blocko/test.c
+++ b/blocko/test.c
@@ -1,5 +1,8 @@
 #include "blocko.h"
 
+#define GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX    0x9048
+#define GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX  0x9049
+
 int in_test_area(int x, int y, int z)
 {
         if (test_area_x == -1) return false;
@@ -70,11 +73,13 @@ void debrief()
                 float elapsed = ((float)ticks - last_ticks);
                 float frames = frame - last_frame;
 
-                p += snprintf(p, 8000 - (p-buf),
-                                "vmem %0.0fm used of %0.0fm (%0.0f%% free)\n",
-                                (float)(total_kb - avail_kb) / 1000.f,
-                                (float)(total_kb)            / 1000.f,
-                                ((float)avail_kb / total_kb) * 100.f);
+                if (GLEW_NVX_gpu_memory_info) {
+                        p += snprintf(p, 8000 - (p-buf),
+                                      "vmem %0.0fm used of %0.0fm (%0.0f%% free)\n",
+                                      (float)(total_kb - avail_kb) / 1000.f,
+                                      (float)(total_kb)            / 1000.f,
+                                      ((float)avail_kb / total_kb) * 100.f);
+                }
 
                 p += snprintf(p, 8000 - (p-buf),
                                 "%d omp, %0.2f chunk/s\n",
@@ -99,8 +104,11 @@ void debrief()
                                         "Out of room in the glo queue (%d times)\n", gloq_outta_room);
                 gloq_outta_room = 0;
 
-                glGetIntegerv(0x9048, &total_kb);
-                glGetIntegerv(0x9049, &avail_kb);
+                if (GLEW_NVX_gpu_memory_info) {
+                        glGetIntegerv(GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX, &total_kb);
+                        glGetIntegerv(GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &avail_kb);
+                }
+
                 last_ticks = ticks;
                 last_frame = frame;
                 polys = 0;


### PR DESCRIPTION
Those that do not have a Nvidia GPU can now compile without any errors. This should close #4 .